### PR TITLE
nsqd: remove channel messagePump

### DIFF
--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -46,8 +46,6 @@ type Channel struct {
 	backend BackendQueue
 
 	memoryMsgChan chan *Message
-	clientMsgChan chan *Message
-	exitChan      chan int
 	exitFlag      int32
 	exitMutex     sync.RWMutex
 
@@ -81,8 +79,6 @@ func NewChannel(topicName string, channelName string, ctx *context,
 		topicName:      topicName,
 		name:           channelName,
 		memoryMsgChan:  make(chan *Message, ctx.nsqd.getOpts().MemQueueSize),
-		clientMsgChan:  make(chan *Message),
-		exitChan:       make(chan int),
 		clients:        make(map[int64]Consumer),
 		deleteCallback: deleteCallback,
 		ctx:            ctx,
@@ -111,8 +107,6 @@ func NewChannel(topicName string, channelName string, ctx *context,
 			ctx.nsqd.getOpts().SyncTimeout,
 			ctx.nsqd.getOpts().Logger)
 	}
-
-	go c.messagePump()
 
 	c.ctx.nsqd.Notify(c)
 
@@ -174,8 +168,6 @@ func (c *Channel) exit(deleted bool) error {
 	}
 	c.RUnlock()
 
-	close(c.exitChan)
-
 	if deleted {
 		// empty the queue (deletes the backend files, too)
 		c.Empty()
@@ -196,15 +188,8 @@ func (c *Channel) Empty() error {
 		client.Empty()
 	}
 
-	clientMsgChan := c.clientMsgChan
 	for {
 		select {
-		case _, ok := <-clientMsgChan:
-			if !ok {
-				// c.clientMsgChan may be closed while in this loop
-				// so just remove it from the select so we can make progress
-				clientMsgChan = nil
-			}
 		case <-c.memoryMsgChan:
 		default:
 			goto finish
@@ -219,13 +204,6 @@ finish:
 // it does not drain inflight/deferred because it is only called in Close()
 func (c *Channel) flush() error {
 	var msgBuf bytes.Buffer
-
-	// messagePump is responsible for closing the channel it writes to
-	// this will read until it's closed (exited)
-	for msg := range c.clientMsgChan {
-		c.ctx.nsqd.logf("CHANNEL(%s): recovered buffered message from clientMsgChan", c.name)
-		writeMessageToBackend(&msgBuf, msg, c.backend)
-	}
 
 	if len(c.memoryMsgChan) > 0 || len(c.inFlightMessages) > 0 || len(c.deferredMessages) > 0 {
 		c.ctx.nsqd.logf("CHANNEL(%s): flushing %d memory %d in-flight %d deferred messages to backend",
@@ -264,7 +242,9 @@ finish:
 }
 
 func (c *Channel) Depth() int64 {
-	return int64(len(c.memoryMsgChan)) + c.backend.Depth() + int64(atomic.LoadInt32(&c.bufferedCount))
+	return int64(len(c.memoryMsgChan)) +
+		c.backend.Depth() +
+		int64(atomic.LoadInt32(&c.bufferedCount))
 }
 
 func (c *Channel) Pause() error {
@@ -534,46 +514,6 @@ func (c *Channel) addToDeferredPQ(item *pqueue.Item) {
 	c.deferredMutex.Lock()
 	heap.Push(&c.deferredPQ, item)
 	c.deferredMutex.Unlock()
-}
-
-// messagePump reads messages from either memory or backend and sends
-// messages to clients over a go chan
-func (c *Channel) messagePump() {
-	var msg *Message
-	var buf []byte
-	var err error
-
-	for {
-		// do an extra check for closed exit before we select on all the memory/backend/exitChan
-		// this solves the case where we are closed and something else is draining clientMsgChan into
-		// backend. we don't want to reverse that
-		if atomic.LoadInt32(&c.exitFlag) == 1 {
-			goto exit
-		}
-
-		select {
-		case msg = <-c.memoryMsgChan:
-		case buf = <-c.backend.ReadChan():
-			msg, err = decodeMessage(buf)
-			if err != nil {
-				c.ctx.nsqd.logf("ERROR: failed to decode message - %s", err)
-				continue
-			}
-		case <-c.exitChan:
-			goto exit
-		}
-
-		msg.Attempts++
-
-		atomic.StoreInt32(&c.bufferedCount, 1)
-		c.clientMsgChan <- msg
-		atomic.StoreInt32(&c.bufferedCount, 0)
-		// the client will call back to mark as in-flight w/ its info
-	}
-
-exit:
-	c.ctx.nsqd.logf("CHANNEL(%s): closing ... messagePump", c.name)
-	close(c.clientMsgChan)
 }
 
 func (c *Channel) processDeferredQueue(t int64) bool {

--- a/nsqd/channel_test.go
+++ b/nsqd/channel_test.go
@@ -26,7 +26,7 @@ func TestPutMessage(t *testing.T) {
 	msg := NewMessage(id, []byte("test"))
 	topic.PutMessage(msg)
 
-	outputMsg := <-channel1.clientMsgChan
+	outputMsg := <-channel1.memoryMsgChan
 	equal(t, msg.ID, outputMsg.ID)
 	equal(t, msg.Body, outputMsg.Body)
 }
@@ -48,11 +48,11 @@ func TestPutMessage2Chan(t *testing.T) {
 	msg := NewMessage(id, []byte("test"))
 	topic.PutMessage(msg)
 
-	outputMsg1 := <-channel1.clientMsgChan
+	outputMsg1 := <-channel1.memoryMsgChan
 	equal(t, msg.ID, outputMsg1.ID)
 	equal(t, msg.Body, outputMsg1.Body)
 
-	outputMsg2 := <-channel2.clientMsgChan
+	outputMsg2 := <-channel2.memoryMsgChan
 	equal(t, msg.ID, outputMsg2.ID)
 	equal(t, msg.Body, outputMsg2.Body)
 }
@@ -197,12 +197,6 @@ func TestChannelHealth(t *testing.T) {
 	topic := nsqd.GetTopic("test")
 
 	channel := topic.GetChannel("channel")
-	// cause channel.messagePump to exit so we can set channel.backend without
-	// a data race. side effect is it closes clientMsgChan, and messagePump is
-	// never restarted. note this isn't the intended usage of exitChan but gets
-	// around the data race without more invasive changes to how channel.backend
-	// is set/loaded.
-	channel.exitChan <- 1
 
 	channel.backend = &errorBackendQueue{}
 

--- a/nsqd/protocol_v2_test.go
+++ b/nsqd/protocol_v2_test.go
@@ -182,10 +182,13 @@ func TestMultipleConsumerV2(t *testing.T) {
 		equal(t, err, nil)
 
 		go func(c net.Conn) {
-			resp, _ := nsq.ReadResponse(c)
-			_, data, _ := nsq.UnpackResponse(resp)
-			recvdMsg, _ := decodeMessage(data)
-			msgChan <- recvdMsg
+			resp, err := nsq.ReadResponse(c)
+			equal(t, err, nil)
+			_, data, err := nsq.UnpackResponse(resp)
+			equal(t, err, nil)
+			msg, err := decodeMessage(data)
+			equal(t, err, nil)
+			msgChan <- msg
 		}(conn)
 	}
 
@@ -401,9 +404,9 @@ func TestPausing(t *testing.T) {
 	topic.PutMessage(msg)
 
 	// allow the client to possibly get a message, the test would hang indefinitely
-	// if pausing was not working on the internal clientMsgChan read
+	// if pausing was not working
 	time.Sleep(50 * time.Millisecond)
-	msg = <-channel.clientMsgChan
+	msg = <-channel.memoryMsgChan
 	equal(t, msg.Body, []byte("test body2"))
 
 	// unpause the channel... the client should now be pushed a message


### PR DESCRIPTION
(Pushing up rebased branches I've had laying around locally for ages)

This removes a goroutine per channel and simplifies exit logic.